### PR TITLE
seed file fix to account for the missing email validation

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,6 @@
-jacob = User.create(username: "jacob", password: "football", password_confirmation: "football")
+# frozen_string_literal: true
+
+User.create!(username: 'jacob',
+             email: 'jacob@helloworld.com',
+             password: 'football',
+             password_confirmation: 'football')


### PR DESCRIPTION
just a quick fix for the seed file which currently was causing
```rb
ActiveRecord::RecordInvalid: Validation failed: Email can't be blank
```
upon calling
```shell
rake db:seed
```