### PR TITLE
add sup_last_requested_at to user and index on created_at for notes

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -98,7 +98,7 @@ class MemosController < ApplicationController
           user: grab.user,
           actor: current_user,
           cross_ref: memo,
-          meta: { 
+          meta: {
             grab_id: grab.hashid,
             summary: memo.message,
             buttcoin_earned: buttcoin_earned

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -2,12 +2,15 @@ class NotesController < ApplicationController
   before_action :authenticate_user
 
   def any
-    notes_count = current_user.notes.count
+    s_l_r_at = current_user.sup_last_requested_at
+    notes_count = current_user.notes.where('created_at >= ?', s_l_r_at).count
 
     render json: { pending: notes_count }
   end
 
   def index
+    current_user.touch(:sup_last_requested_at)
+
     page = params[:page] || 1
     per_page = params[:per_page] || 25
 

--- a/db/migrate/20180421163828_add_last_requested_to_user.rb
+++ b/db/migrate/20180421163828_add_last_requested_to_user.rb
@@ -1,0 +1,6 @@
+class AddLastRequestedToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :sup_last_requested_at, :datetime
+    add_index :notes, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180301201222) do
+ActiveRecord::Schema.define(version: 20180421163828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20180301201222) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["actor_id"], name: "index_notes_on_actor_id"
+    t.index ["created_at"], name: "index_notes_on_created_at"
     t.index ["cross_ref_type", "cross_ref_id"], name: "index_notes_on_cross_ref_type_and_cross_ref_id"
     t.index ["user_id"], name: "index_notes_on_user_id"
     t.index ["variant"], name: "index_notes_on_variant"
@@ -96,6 +97,7 @@ ActiveRecord::Schema.define(version: 20180301201222) do
     t.string "name"
     t.string "bio"
     t.text "blocked", default: [], array: true
+    t.datetime "sup_last_requested_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
as per https://github.com/yothinko/screenhole/issues/59

- add sup_last_requested_at to user
- use sup_last_requested_at to query for unread notifications server side
- does get updated every time a user visits `/sup` screen using UI
- does *not* get updated just by querying (sending a `get` request to) `/sup/any` via UI
- 🛑first time 👉 will show 0 new notifications until they visit `/sup` page b/c `sup_last_requested_at` will be nil initially