### PR TITLE
fix created_at and updated_at fields of notes that was missed last week

### DIFF
--- a/db/migrate/20180501173139_back_fill_memos_fix.rb
+++ b/db/migrate/20180501173139_back_fill_memos_fix.rb
@@ -24,8 +24,8 @@ class BackFillMemosFix < ActiveRecord::Migration[5.1]
           summary: memo.message,
           buttcoin_earned: buttcoin_earned
         },
-        created_at: grab.created_at,
-        updated_at: grab.created_at
+        created_at: memo.created_at,
+        updated_at: memo.created_at
       )
     end
 


### PR DESCRIPTION
- ok @jake so, since the mixup was last week, I figured we would leave all new stuff created since then and only focus on pre-backfill via `Memo.where('Date(created_at) < ?', '2018-04-24')`.
- also, as we discussed I made sure that the `created_at` and `updated_at` fields not be populated by rails by manually toggling `record_timestamps`
- so now... after this... the re-created notes' `created_at` and `updated_at` should be aligned with the `grab`'s `created_at` value
- ref https://github.com/yothinko/screenhole/issues/58