### PR TITLE
fix the regex and logic for sanitizing grabs description

### DIFF
--- a/app/controllers/grabs_controller.rb
+++ b/app/controllers/grabs_controller.rb
@@ -34,7 +34,8 @@ class GrabsController < ApplicationController
 
     if params[:description].present?
       description = params[:description][0..description_limit]
-      grab.description = description.gsub(/[^0-9A-z@#.\-]/, '_')
+      sanitized = description.gsub(/[^0-9A-z@#.\-]/, 'SHReplaceMe')
+      grab.description = sanitized.gsub(/SHReplaceMe/, ' ').strip
     end
 
     begin


### PR DESCRIPTION
- instead of `How_cool_is_that_` we should have `How cool is that'
- saw an error which was due to `.gsub(/[^0-9A-z@#.\-]/, '_')` which was simply replacing with `_` and I did not convert back to spaces
- so now it is a two step process:
  1) `.gsub(/[^0-9A-z@#.\-]/, 'SHReplaceMe')` replace these thingys with `SHReplaceMe` keyword
  2) replace `SHReplaceMe` keyword with spaces

so in the end a string like: 
```
hello world and stuff @things #soon and stuff <script> ____ dsadjsadas fasfas ** &^!@(#)@$)(#(^)
```
would turn to
```
hello world and stuff @things #soon and stuff  script  ____ dsadjsadas fasfas     ^ @ # @   # ^
```