### PR TITLE
Add support for a "directory" of users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
   before_action :authenticate_user, except: [:show, :create]
 
+  def index
+    render json: User.visible_in_directory
+  end
+
   def show
     username = params[:id].strip.downcase if params[:id]
     render json: User.find_by(username: username), include: ['grabs.*', 'notes.*']
@@ -31,7 +35,7 @@ class UsersController < ApplicationController
     if user.save
       invite.update_attribute(:invited_id, user.id)
       jwt_token = Knock::AuthToken.new(payload: user.to_token_payload ).token
-      
+
       render json: user, meta: { jwt: jwt_token }
     else
       respond_with_errors(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ApplicationRecord
 
   before_validation :normalize_username
 
+  scope :visible_in_directory, -> { all }
+
   def buttcoin_transaction(amount, note=nil)
     Buttcoin.create(user: self, amount: amount, note: note)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, only: [:show, :create] do
+  resources :users, only: [:index, :show, :create] do
     post 'block' => 'users#block'
     post 'unblock' => 'users#unblock'
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -9,6 +9,27 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     }
   end
 
+  test 'should return a list of users from #index' do
+    get('/users', headers: authenticated_header)
+
+    assert_response(:success)
+
+    users = JSON.parse(@response.body).try(:[], 'users')
+
+    assert_not_nil(users)
+    assert_kind_of(Array, users)
+
+    first_user = users.first
+
+    assert_not_nil(first_user)
+    assert_equal('getaclue_1', users(:one).username)
+  end
+
+  test 'should not allow access to list of users if non-authenticated' do
+    get('/users')
+    assert_response(401)
+  end
+
   test 'should get #show' do
     user = users(:one).username
 
@@ -53,14 +74,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update user #update' do
-    params = { 
-      auth: { 
-        username: 'getaclue', 
-        email: 'info@getaclue.me', 
-        name: 'Kluew Alex', 
-        bio: 'Hello World', 
-        password: 'newp4ssw0rd', 
-        password_confirmation: 'newp4ssw0rd' 
+    params = {
+      auth: {
+        username: 'getaclue',
+        email: 'info@getaclue.me',
+        name: 'Kluew Alex',
+        bio: 'Hello World',
+        password: 'newp4ssw0rd',
+        password_confirmation: 'newp4ssw0rd'
       }
     }
 


### PR DESCRIPTION
This adds a new endpoint at `/users` that returns a list of all the
users in Screenhole. I've got another PR for jake/screenhole-web that
implements a Yellow Pages-style UI.

I was kind of intrigued to see who's actually using the thing and
thought this might be a fun thing.

As part of this, I've added a `visible_in_directory` scope to the `User`
model. Right now it just returns everyone, but we can use it to filter
out people for whatever reason further down the line.

P.S. Minitest suuuuuuuuuucks