### PR TITLE
Feat: add authentication mechanism for websockets

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,19 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+
+    def find_verified_user
+      token = request.params[:token]
+      user = User.from_token_payload(token)
+      user
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,21 @@ class User < ApplicationRecord
   end
 
   def self.from_token_payload(payload)
-    self.find payload["sub"]
+    if payload["sub"]
+      self.find payload["sub"]
+    else
+      begin
+        _decoded_token = Base64.decode64(payload)
+        _token = Knock::AuthToken.new(token: _decoded_token)
+        if _token.payload && _token.payload["sub"]
+          self.find _token.payload["sub"]
+        else
+          fail 'Missing sub payload'
+        end
+      rescue
+        return nil
+      end
+    end
   end
 
   def self.from_token_request(request)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literals: true
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  test '#from_token_payload with sub' do
+    user = users(:one)
+
+    token = {}
+    token["sub"] = user.hashid
+
+    result = User.from_token_payload(token)
+
+    assert_equal user.id, result.id
+  end
+
+  test '#from_token_payload with jwt token for connection#find_verified_user' do
+    user = users(:one)
+    _token = Knock::AuthToken.new(payload: { sub: user.id }).token
+    _encoded_token = Base64.encode64(_token)
+
+    result = User.from_token_payload(_encoded_token)
+
+    assert_equal user.id, result.id
+  end
+
+    test '#from_token_payload with guest token for action cable connect' do
+    _token = "guest"
+    _encoded_token = Base64.encode64(_token)
+
+    result = User.from_token_payload(_encoded_token)
+
+    assert_nil result
+
+    _token = "anything else really"
+    _encoded_token = Base64.encode64(_token)
+
+    result = User.from_token_payload(_encoded_token)
+
+    assert_nil result
+  end
+end


### PR DESCRIPTION
- wanted to add some kind of mechanism for sockets but couldn't find a good one
- found this one and it makes sense I think
- most logic is here:
![image](https://user-images.githubusercontent.com/6380439/41814139-dfc74f9a-7712-11e8-85b3-e94fee51c33b.png)
- took a minute b/c the method isn't really mentioned - read their source code 🤷‍♂️
- anyways this is just some road work before we can work on personalized notifications and so on, I think
- depends on https://github.com/jake/screenhole-web/pull/36