### PR TITLE
Add country code support to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'hashid-rails'
 gem 'kaminari'
 gem 'sentry-raven'
 gem 'skylight'
+gem 'countries'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,10 @@ GEM
     case_transform (0.2)
       activesupport
     concurrent-ruby (1.0.5)
+    countries (3.0.0)
+      i18n_data (~> 0.8.0)
+      sixarm_ruby_unaccent (~> 1.1)
+      unicode_utils (~> 1.4)
     crass (1.0.2)
     docile (1.3.0)
     erubi (1.7.0)
@@ -80,6 +84,7 @@ GEM
       hashids (~> 1.0)
     hashids (1.0.4)
     i18n (0.8.6)
+    i18n_data (0.8.0)
     jmespath (1.3.1)
     json (2.1.0)
     jsonapi-renderer (0.1.3)
@@ -161,6 +166,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    sixarm_ruby_unaccent (1.2.0)
     skylight (3.1.2)
       skylight-core (= 3.1.2)
     skylight-core (3.1.2)
@@ -181,6 +187,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
+    unicode_utils (1.4.0)
     uniform_notifier (1.11.0)
     web-console (3.5.1)
       actionview (>= 5.0)
@@ -200,6 +207,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bullet
   byebug
+  countries
   hashid-rails
   kaminari
   knock

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -91,6 +91,6 @@ class UsersController < ApplicationController
   end
 
   def auth_params
-    params.require(:auth).permit(:email, :username, :password, :password_confirmation, :code, :name, :bio)
+    params.require(:auth).permit(:email, :username, :password, :password_confirmation, :code, :name, :bio, :country_code)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  DEFAULT_COUNTRY_EMOJI = '🏁'.freeze
+
   include Hashid::Rails
 
   validates_uniqueness_of :username, case_sensitive: false, allow_blank: false
@@ -9,6 +11,8 @@ class User < ApplicationRecord
   has_secure_password
   validates_length_of :password, minimum: 6, if: :password_digest_changed?
   validates_presence_of :password_confirmation, if: :password_digest_changed?
+
+  validates_inclusion_of :country_code, allow_blank: true, in: ISO3166::Country.codes
 
   has_many :grabs, dependent: :destroy
   has_many :chomments, dependent: :destroy
@@ -40,6 +44,10 @@ class User < ApplicationRecord
 
   def to_token_payload
     { sub: hashid }
+  end
+
+  def country_emoji
+    ISO3166::Country[country_code].try(:emoji_flag) || DEFAULT_COUNTRY_EMOJI
   end
 
   def self.from_token_payload(payload)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -3,6 +3,9 @@ class UserSerializer < ActiveModel::Serializer
 
   attributes :username, :created_at, :gravatar_hash, :name, :bio, :blocked
 
+  attribute :country_code
+  attribute :country_emoji
+
   attribute :email, if: :is_current_user?
 
   # has_many :grabs

--- a/db/migrate/20190117223851_add_country_code_to_users.rb
+++ b/db/migrate/20190117223851_add_country_code_to_users.rb
@@ -1,0 +1,5 @@
+class AddCountryCodeToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :country_code, :string, limit: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180717221026) do
+ActiveRecord::Schema.define(version: 20190117223851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 20180717221026) do
     t.text "blocked", default: [], array: true
     t.datetime "sup_last_requested_at"
     t.integer "grabs_count"
+    t.string "country_code", limit: 2
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -39,6 +39,20 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Software Engineer, EIT - I read your beautifully tracked emails using plain text - https://dailyvibes.ca  – http://elderoost.com  – http://t.me/getaclue', user_data['bio']
   end
 
+  test 'includes a country code and emoji if supplied' do
+    user = users(:one)
+    user.country_code = 'SE'
+    user.save!
+
+    get "/users/#{user.username}"
+
+    result = JSON.parse(@response.body)['user']
+
+    assert_response :success
+    assert_equal 'SE', result['country_code']
+    assert_equal '🇸🇪', result['country_emoji']
+  end
+
   test 'should ignore username case sensitivity in #show' do
     get "/users/getaclue_1"
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -38,4 +38,23 @@ class UserTest < ActiveSupport::TestCase
 
     assert_nil result
   end
+
+  test '#country_emoji returns a checkered flag if no country_code is set' do
+    user = users(:one)
+
+    assert_equal user.country_emoji, '🏁'
+  end
+
+  test '#country_emoji returns the relevant flag if a valid country_code is set' do
+    user = users(:one)
+    user.country_code = 'FI'
+
+    assert_equal user.country_emoji, '🇫🇮'
+  end
+
+  test 'country_code only accepts valid countries' do
+    user = users(:one)
+    user.country_code = 'big dick energy'
+    assert_equal user.valid?, false
+  end
 end


### PR DESCRIPTION
Scrutinise code thoroughly; author is incompetent.

This allows users to set a country code on their account, and subsequently exposes that country code and the associated flag emoji via the API.