### PR TITLE
Chomment-driven Presence – Part I

### DIFF
--- a/app/channels/chomments_channel.rb
+++ b/app/channels/chomments_channel.rb
@@ -1,5 +1,6 @@
 class ChommentsChannel < ApplicationCable::Channel
   def subscribed
+    current_user.try(:presence).try(:appear!)
     stream_from "chomments_messages"
   end
 
@@ -8,5 +9,6 @@ class ChommentsChannel < ApplicationCable::Channel
   end
 
   def unsubscribed
+    current_user.try(:presence).try(:disappear!)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,8 +65,16 @@ class User < ApplicationRecord
     self.find_by(username: username)
   end
 
+  def online?
+    presence.present?
+  end
+
   private
   def normalize_username
     self.username = username.strip.downcase if username
+  end
+
+  def presence
+    @presence ||= UserPresenceService.new(id: hashid)
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -12,6 +12,8 @@ class UserSerializer < ActiveModel::Serializer
 
   attribute :roles
 
+  attribute :online?, key: :is_online
+
   def roles
     roles = []
 

--- a/app/services/user_presence_service.rb
+++ b/app/services/user_presence_service.rb
@@ -1,0 +1,27 @@
+class UserPresenceService
+  SET_KEY = 'sup' # screenhole user presence
+
+  def initialize(id:)
+    @id = id.to_s
+  end
+
+  def appear!
+    redis.sadd(SET_KEY, id)
+  end
+
+  def disappear!
+    redis.srem(SET_KEY, id)
+  end
+
+  def present?
+    redis.sismember(SET_KEY, id)
+  end
+
+  private
+
+  attr_reader :id
+
+  def redis
+    @redis ||= Redis.current
+  end
+end


### PR DESCRIPTION
This is the first in a series of PRs that are designed to facilitate presence support for users on Screenhole.

This:
- Tracks user presence in a Redis set
- Exposes it via the REST API as an `is_online` field on users
- Adds / removes from Redis set when a user is connected / disconnected from the `ChommentsChannel`

Once this implementation is confirmed to work, the next step will be broadcasting presence changes to all users. But, baby steps – we want to implement this in phases.