### PR TITLE
Don't expose notes at /users/:username

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
 
   def show
     username = params[:id].strip.downcase if params[:id]
-    render json: User.find_by(username: username), include: ['grabs.*', 'notes.*']
+    render json: User.find_by(username: username), include: ['grabs.*']
   end
 
   def create

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,9 +9,6 @@ class UserSerializer < ActiveModel::Serializer
 
   attribute :email, if: :is_current_user?
 
-  # has_many :grabs
-  has_many :notes, if: :is_current_user?
-
   attribute :stats
 
   attribute :roles


### PR DESCRIPTION
This is creating an unnecessarily complex query when notes are not used anywhere in user serializer or the associated handlers in the web app.