### PR TITLE
Add Puma worker killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'skylight'
 gem 'countries'
 gem 'tzinfo'
 gem 'tzinfo-data'
+gem 'puma_worker_killer'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
+    get_process_mem (0.2.3)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     hashid-rails (1.1.0)
@@ -126,6 +127,9 @@ GEM
       mini_portile2 (~> 2.3.0)
     pg (0.21.0)
     puma (3.12.0)
+    puma_worker_killer (0.1.0)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7, < 4)
     rack (2.0.3)
     rack-cors (1.0.1)
     rack-test (0.7.0)
@@ -216,6 +220,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   puma (~> 3.7)
+  puma_worker_killer
   rack-cors
   rails (~> 5.1.4)
   redis

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,6 +37,10 @@ preload_app!
 # are forked to prevent connection leakage.
 #
 before_fork do
+  require 'puma_worker_killer'
+
+  PumaWorkerKiller.enable_rolling_restart
+
   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
 end
 


### PR DESCRIPTION
Rather than fixing your memory leaks, roll your workers every few hours!