### PR TITLE
Add username blacklist

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,21 @@
 class User < ApplicationRecord
+  # The following usernames correspond to top-level routes in the frontend, meaning their
+  # user profile page will never be visible.
+  USERNAME_BLACKLIST = %w(
+    wtf
+    eula
+    privacy
+    apps
+    code
+    login
+    register
+    peeps
+    invite
+    logout
+    settings
+    sup
+  ).freeze
+
   POTENTIAL_BADGERS = [
     ChatterboxBadger,
     ContributorBadger,
@@ -6,12 +23,15 @@ class User < ApplicationRecord
     OversharerBadger,
     ElderlyBadger
   ].freeze
+
   DEFAULT_COUNTRY_EMOJI = '🏁'.freeze
 
   include Hashid::Rails
 
   validates_uniqueness_of :username, case_sensitive: false, allow_blank: false
   validates_uniqueness_of :email, case_sensitive: false, allow_blank: false
+
+  validates_exclusion_of :username, in: USERNAME_BLACKLIST
 
   validates_presence_of :username, :email
 

--- a/lib/tasks/username_blacklist.rake
+++ b/lib/tasks/username_blacklist.rake
@@ -1,0 +1,8 @@
+namespace :username_blacklist do
+  task enforce: :environment do
+    User.where(username: User::USERNAME_BLACKLIST).each do |user|
+      user.username = "naughty_#{user.username}"
+      user.save!
+    end
+  end
+end


### PR DESCRIPTION
This stops users registering with a username that is already occupied by a top-level route on the frontend.