### PR TITLE
Block wonky usernames

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
   validates_uniqueness_of :email, case_sensitive: false, allow_blank: false
 
   validates_exclusion_of :username, in: Blacklist.words
+  validates_format_of :username, with: /\A[A-Za-z0-9_]+\z/
 
   validates_presence_of :username, :email
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 describe User, type: :model do
   subject { create(:user) }
 
+  describe 'validations' do
+    it { is_expected.to allow_value('peterParker_2018').for(:username) }
+    it { is_expected.to_not allow_value('sam@example.com').for(:username) }
+  end
+
   describe 'associations' do
     it { is_expected.to have_many(:hole_memberships) }
     it { is_expected.to have_many(:holes).through(:hole_memberships) }


### PR DESCRIPTION
Right now you can create a username with any characters in, which causes
various issues. This adds a check that prevents usernames containing
anything other than alphanumeric characters and underscores.