### PR TITLE
Implement hard subdomain blacklist

### DIFF
--- a/app/models/hole.rb
+++ b/app/models/hole.rb
@@ -1,13 +1,4 @@
 class Hole < ApplicationRecord
-  HARD_BLACKLIST_EXACT_MATCH = %w[
-    api
-    news
-    old
-    preview
-    staging-api
-    staging
-    www
-  ].freeze
 
   HARD_BLACKLIST_REGEX = [
     # anti-impersonation
@@ -33,7 +24,7 @@ class Hole < ApplicationRecord
     presence: true,
     format: /\A[a-z0-9\-]+\z/,
     length: { minimum: 3, maximum: 30 },
-    exclusion: Blacklist.words + HARD_BLACKLIST_EXACT_MATCH
+    exclusion: Blacklist.words
   )
 
   HARD_BLACKLIST_REGEX.each do |r|

--- a/config/blacklist.txt
+++ b/config/blacklist.txt
@@ -67,7 +67,6 @@ alerts
 alpha
 amp
 analytics
-api
 app
 apps
 asc
@@ -305,7 +304,6 @@ my
 net
 network
 new
-news
 newsletter
 newsletters
 next
@@ -440,7 +438,6 @@ ssladmin
 ssladministrator
 sslwebmaster
 stage
-staging
 stat
 static
 statistics
@@ -511,7 +508,6 @@ widgets
 wiki
 wpad
 write
-www
 www-data
 www1
 www2
@@ -525,3 +521,12 @@ tagged
 plus
 rails
 snapper
+
+# Screenhole-specific
+api
+news
+old
+preview
+staging-api
+staging
+www

--- a/lib/blacklist.rb
+++ b/lib/blacklist.rb
@@ -1,6 +1,6 @@
 module Blacklist
   def self.words
-    @words ||= file.split("\n").map(&:strip)
+    @words ||= file.split("\n").map(&:strip).reject(&:blank?).reject { |l| l.starts_with?('#') }
   end
 
   def self.file

--- a/spec/models/hole_spec.rb
+++ b/spec/models/hole_spec.rb
@@ -20,18 +20,10 @@ RSpec.describe Hole, type: :model do
         it { is_expected.to_not allow_value('telnet').for(:subdomain) }
       end
 
-      describe 'hard blacklist' do
-        describe 'exact match' do
-          Hole::HARD_BLACKLIST_EXACT_MATCH.each do |phrase|
-            it { is_expected.to_not allow_value(phrase).for(:subdomain) }
-          end
-        end
-
-        describe 'regex' do
-          it { is_expected.to_not allow_value('thinko-hiring').for(:subdomain) }
-          it { is_expected.to_not allow_value('screenhole-admin').for(:subdomain) }
-          it { is_expected.to_not allow_value('free-lenovo-thinkpad').for(:subdomain) }
-        end
+      describe 'regex blacklist' do
+        it { is_expected.to_not allow_value('thinko-hiring').for(:subdomain) }
+        it { is_expected.to_not allow_value('screenhole-admin').for(:subdomain) }
+        it { is_expected.to_not allow_value('free-lenovo-thinkpad').for(:subdomain) }
       end
     end
   end

--- a/spec/models/hole_spec.rb
+++ b/spec/models/hole_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe Hole, type: :model do
       it { is_expected.to validate_length_of(:subdomain).is_at_most(30) }
       it { is_expected.to allow_value('abc-def-123').for(:subdomain) }
       it { is_expected.to_not allow_value('With Non-Alpha Chars!').for(:subdomain) }
+
+      describe 'generic blacklist' do
+        it { is_expected.to_not allow_value('telnet').for(:subdomain) }
+      end
+
+      describe 'hard blacklist' do
+        describe 'exact match' do
+          Hole::HARD_BLACKLIST_EXACT_MATCH.each do |phrase|
+            it { is_expected.to_not allow_value(phrase).for(:subdomain) }
+          end
+        end
+
+        describe 'regex' do
+          it { is_expected.to_not allow_value('thinko-hiring').for(:subdomain) }
+          it { is_expected.to_not allow_value('screenhole-admin').for(:subdomain) }
+          it { is_expected.to_not allow_value('free-lenovo-thinkpad').for(:subdomain) }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
There are certain regular expressions and phrases that we want to ensure
are never allowed for the stability and integrity of the product. This
implements a "hard blacklist" for them.